### PR TITLE
Support multiarch images (arm64 and amd64)

### DIFF
--- a/.github/workflows/build-publish.yaml
+++ b/.github/workflows/build-publish.yaml
@@ -4,27 +4,41 @@ on:
   workflow_dispatch:
   push:
     tags:
-      - "*"
+      - "v*"
+  pull_request:
+    branches:
+      - "main"
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAMES: "beegfs-all\nbeegfs-mgmtd\nbeegfs-meta\nbeegfs-storage"
+  NAMESPACE: thinkparq
+  DOCKER_BUILDX_BUILD_PLATFORMS: "linux/amd64,linux/arm64"  
 
 jobs:
   publish-images:
     runs-on: ubuntu-22.04
     timeout-minutes: 10
+    strategy:
+      matrix:
+        include:
+          - image_name: beegfs-all
+          - image_name: beegfs-mgmtd
+          - image_name: beegfs-meta
+          - image_name: beegfs-storage
     permissions:
       packages: write
       contents: read
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-tags: true
+          fetch-depth: 0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2      
+        uses: docker/setup-buildx-action@v3    
 
       - name: Log in to the GitHub Container Registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -35,27 +49,60 @@ jobs:
         with:
           cosign-release: "v2.1.1"          
 
-      - name: Build, tag, sign, and push the container images to GitHub Container Registry
+      - name: Determine what version of BeeGFS to build images for based on the last tag
+        id: determine_beegfs_version
         run: |
-          beegfs_version=$(git describe --tags --match '*.*' --abbrev=10)
-          names=$(echo "${{ env.IMAGE_NAMES }}" | tr '\n' ' ')
+          last_version=$(git describe --tags --abbrev=0)
+          echo "LAST_VERSION=$last_version" >> $GITHUB_OUTPUT
 
-          for name in $names; do
-            image=ghcr.io/thinkparq/${name}:${beegfs_version}
-            docker build -t $image --build-arg BEEGFS_VERSION=${beegfs_version} --target ${name} .
-            docker push $image
+      - name: Determine metadata for BeeGFS image
+        id: meta
+        uses: docker/metadata-action@v5.5.1
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.NAMESPACE }}/${{ matrix.image_name }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}},prefix=
+            type=semver,pattern={{major}}.{{minor}},prefix=
 
-            DIGEST=$(docker image inspect $image --format '{{index .RepoDigests 0}}')
-            cosign sign --yes --key env://COSIGN_PRIVATE_KEY \
-            -a "repo=${{ github.repository }}" \
-            -a "run=${{ github.run_id }}" \
-            -a "ref=${{ github.sha }}" \
-            $DIGEST
+      - name: Build and push image for each supported platform
+        uses: docker/build-push-action@v5.1.0
+        id: build_and_push
+        with:
+          context: .
+          platforms: "${{ env.DOCKER_BUILDX_BUILD_PLATFORMS }}"
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          # If provenance is not set to false then the manifest list will contain unknown platform
+          # entries that are also displayed in GitHub. Some detail on why this is needed in:
+          # https://github.com/docker/buildx/issues/1509 and
+          # https://github.com/docker/build-push-action/issues/755#issuecomment-1607792956.
+          provenance: false
+          # Reference: https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#adding-a-description-to-multi-arch-images
+          outputs: type=image,name=target,annotation-index.org.opencontainers.image.description=Container images for the BeeGFS server services allowing fully containerized BeeGFS deployments
+          build-args: |
+            BEEGFS_VERSION=${{ steps.determine_beegfs_version.outputs.LAST_VERSION }}
+          target: ${{ matrix.image_name }}
 
-            docker tag $image ghcr.io/thinkparq/${name}:latest
-            docker push ghcr.io/thinkparq/${name}:latest
-
+      # Adapted from:
+      # https://github.blog/2021-12-06-safeguard-container-signing-capability-actions/
+      # https://github.com/sigstore/cosign-installer#usage
+      # Note we only sign the multi-platform image manifest, not the individual platform specific images.
+      - name: Sign container image with Cosign
+        run: |
+          images=""
+          for tag in ${TAGS}; do
+            images+="${tag}@${DIGEST} "
           done
+          cosign sign --yes --key env://COSIGN_PRIVATE_KEY \
+          -a "repo=${{ github.repository }}" \
+          -a "run=${{ github.run_id }}" \
+          -a "ref=${{ github.sha }}" \
+           ${images}
         env:
+          TAGS: ${{ steps.meta.outputs.tags }}
           COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_PRIVATE_KEY }}
           COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
+          DIGEST: ${{ steps.build_and_push.outputs.digest }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@
 
 # Using multi-stage docker with the same base image for all daemons.
 
-FROM debian:10.12-slim AS base
+FROM --platform=$TARGETPLATFORM debian:10.12-slim AS base
 ARG DEBIAN_FRONTEND=noninteractive
 ENV PATH="/opt/beegfs/sbin/:${PATH}"
 # Note this is the default used when no version is specified.
@@ -50,7 +50,7 @@ RUN mkdir -p /data/beegfs
 
 
 # Build beegfs-mgmtd docker image with `docker build -t repo/image-name  --target beegfs-mgmtd .`  
-FROM base AS beegfs-mgmtd
+FROM --platform=$TARGETPLATFORM  base AS beegfs-mgmtd
 ARG BEEGFS_SERVICE="beegfs-mgmtd"
 ENV BEEGFS_SERVICE=$BEEGFS_SERVICE
 RUN apt-get update && apt-get install $BEEGFS_SERVICE libbeegfs-ib -y && rm -rf /var/lib/apt/lists/* 
@@ -58,7 +58,7 @@ ENTRYPOINT ["/root/start.sh"]
 
 
 # Build beegfs-meta docker image with `docker build -t repo/image-name  --target beegfs-meta .`  
-FROM base AS beegfs-meta
+FROM --platform=$TARGETPLATFORM base AS beegfs-meta
 ARG BEEGFS_SERVICE="beegfs-meta"
 ENV BEEGFS_SERVICE=$BEEGFS_SERVICE
 RUN apt-get update && apt-get install $BEEGFS_SERVICE libbeegfs-ib -y && rm -rf /var/lib/apt/lists/*
@@ -67,7 +67,7 @@ ENTRYPOINT ["/root/start.sh"]
 
 
 # Build beegfs-storage docker image with `docker build -t repo/image-name  --target beegfs-storage .`  
-FROM base AS beegfs-storage
+FROM --platform=$TARGETPLATFORM base AS beegfs-storage
 ARG BEEGFS_SERVICE="beegfs-storage"
 ENV BEEGFS_SERVICE=$BEEGFS_SERVICE
 RUN apt-get update && apt-get install $BEEGFS_SERVICE libbeegfs-ib -y && rm -rf /var/lib/apt/lists/*
@@ -76,7 +76,7 @@ ENTRYPOINT ["/root/start.sh"]
 
 
 # Build beegfs-all docker image with `docker build -t repo/image-name  --target beegfs-all .`  
-FROM base AS beegfs-all
+FROM --platform=$TARGETPLATFORM base AS beegfs-all
 ARG BEEGFS_SERVICE="beegfs-all"
 RUN apt-get update && apt-get install libbeegfs-ib beegfs-mgmtd beegfs-meta beegfs-storage -y && rm -rf /var/lib/apt/lists/*
 RUN rm -rf /etc/beegfs/*conf


### PR DESCRIPTION
### Remaining Work

### Checklist before merging:

- [x] Documentation: Has documentation been added for new functionality? Does any existing documentation need to be updated or removed?
- [x] Tests: Is there adequate test coverage for new functionality? Do any existing tests need to be updated?
- [x] Dependencies: Does this PR rely on any changes to dependencies? If so has the `go.mod` or equivalent been updated to point at a version that contains the related changes?
- [x] Git Hygiene: Is the commit history squashed down reasonably?

### Which issue(s) does this PR address?

No associated issues.

### Does this PR depend on any other PRs to be merged first? 
No

### What does this PR do / why do we need it?

BeeGFS has published packages for both [amd64 and arm64](https://www.beegfs.io/release/beegfs_7.4.2/dists/buster/) for some time and it makes sense to also publish container images for both architectures. We're doing this now because with https://github.com/ThinkParQ/beegfs-csi-driver/pull/24 we added multiarch images for the BeeGFS CSI driver and operator. Now people can also deploy BeeGFS file systems into K8s clusters using arm64 nodes (and there is at least one user wanting to do so).

### Where should the reviewer(s) start reviewing this?

Review changes to the GitHub actions workflow then Dockerfiles.

### Are there any specific topics we should discuss before merging?

No

### What are the next steps after this PR? 

All work items for this task are complete with this PR.