### PR TITLE
feat: add support for building BeeGFS v8 Docker images and v8 docker compose setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,9 @@ RUN mkdir -p /data/beegfs
 FROM --platform=$TARGETPLATFORM  base AS beegfs-mgmtd
 ARG BEEGFS_SERVICE="beegfs-mgmtd"
 ENV BEEGFS_SERVICE=$BEEGFS_SERVICE
-RUN apt-get update && apt-get install $BEEGFS_SERVICE libbeegfs-ib -y && rm -rf /var/lib/apt/lists/* 
+RUN apt-get update && apt-get install $BEEGFS_SERVICE libbeegfs-ib -y && \
+    if [ "${BEEGFS_VERSION%%.*}" -ne 7 ]; then apt-get install libbeegfs-license -y; fi && \
+    rm -rf /var/lib/apt/lists/*
 ENTRYPOINT ["/root/start.sh"]
 
 

--- a/README.md
+++ b/README.md
@@ -44,8 +44,17 @@ docker build -t beegfs-storage:latest --target beegfs-storage .
 
 These Docker images can be run as follows: 
 
-Management: 
+#### Management: 
 
+##### V8 Management
+```
+docker run --privileged \
+    --env beegfs_setup_1="beegfs-mgmtd --init --db-file /mnt/mgmt_tgt_mgmt01/mgmtd.sqlite  --log-target stderr " \
+    --env CONN_AUTH_FILE_DATA="myconnauthsecret" \
+    -it beegfs-mgmtd:latest --db-file /mnt/mgmt_tgt_mgmt01/mgmtd.sqlite  --interfaces eth0,eth1  --log-target stderr --tls-disable true
+```
+
+##### V7 Management
 ```
 docker run --privileged \
     --env beegfs_setup_1="beegfs-setup-mgmtd -p /mnt/mgmt_tgt_mgmt01 -C -S mgmt_tgt_mgmt01" \
@@ -53,7 +62,8 @@ docker run --privileged \
     -it beegfs-mgmtd:latest storeMgmtdDirectory=/mnt/mgmt_tgt_mgmt01 storeAllowFirstRunInit=false connInterfacesList=eth0,eth1
 ```
 
-Metadata: 
+
+#### Metadata: 
 
 ```
 docker run --privileged \
@@ -62,7 +72,7 @@ docker run --privileged \
     -it beegfs-meta:latest storeMetaDirectory=/mnt/meta_01_tgt_0101 storeAllowFirstRunInit=false connInterfacesList=eth0,eth1 sysMgmtdHost=beegfs-management
 ```
 
-Storage:
+#### Storage:
 
 ```
 docker run --privileged \

--- a/examples/docker-compose-v7.yml
+++ b/examples/docker-compose-v7.yml
@@ -27,7 +27,7 @@ services:
       - beegfs_2
     volumes:
       - /beegfs/mgmt_tgt_mgmt01:/mnt/mgmt_tgt_mgmt01
-      # - /beegfs/connauthfile:/etc/beegfs/connauthfile
+      # - /beegfs/connauthfile:/etc/beegfs/conn.auth
 
   beegfs-meta:
     image: ghcr.io/thinkparq/beegfs-meta:latest
@@ -42,7 +42,7 @@ services:
       - beegfs_2
     volumes:
       - /beegfs/meta_01_tgt_0101:/mnt/meta_01_tgt_0101
-      # - /beegfs/connauthfile:/etc/beegfs/connauthfile
+      # - /beegfs/connauthfile:/etc/beegfs/conn.auth
 
   beegfs-storage:
     image: ghcr.io/thinkparq/beegfs-storage:latest
@@ -59,7 +59,7 @@ services:
     volumes:
       - /beegfs/stor_01_tgt_101:/mnt/stor_01_tgt_101
       - /beegfs/stor_01_tgt_102:/mnt/stor_01_tgt_102
-      # - /beegfs/connauthfile:/etc/beegfs/connauthfile
+      # - /beegfs/connauthfile:/etc/beegfs/conn.auth
       
 networks:
   beegfs_1:

--- a/examples/docker-compose-v8.yml
+++ b/examples/docker-compose-v8.yml
@@ -22,17 +22,22 @@ services:
     environment:
       - beegfs_setup_1=beegfs-mgmtd --init --db-file /mnt/mgmt_tgt_mgmt01/mgmtd.sqlite  --log-target stderr 
       - CONN_AUTH_FILE_DATA="Connection_Authentication_file_data"
+    # Enable the line below if you have license key in the environment variable
+    #   - BEEGFS_LICENSE_FILE_DATA=$BEEGFS_LICENSE_FILE_DATA
+    # Enable the two lines below if you have a TLS certificate in the environment variable
+    #   - TLS_KEY_FILE_DATA=$TLS_KEY_FILE_DATA
+    #   - TLS_CERT_FILE_DATA=$TLS_CERT_FILE_DATA
     networks: 
       - beegfs_1
       - beegfs_2
     volumes:
       - /beegfs/mgmt_tgt_mgmt01:/mnt/mgmt_tgt_mgmt01
-      # Enable the line below if you have a license file
-      - /etc/beegfs/license.pem:/etc/beegfs/license.pem
-      # Enable the two lines below if you have a TLS certificate and remove the --tls-disable true from the command line
-      # - /etc/beegfs/key.pem:/etc/beegfs/key.pem
-      # - /etc/beegfs/cert.pem:/etc/beegfs/cert.pem
-      # - /beegfs/connauthfile:/etc/beegfs/conn.auth
+    # Enable the line below if you have a license file
+    #   - /etc/beegfs/license.pem:/etc/beegfs/license.pem
+    # Enable the two lines below if you have a TLS certificate and remove the --tls-disable true from the command line
+    #   - /etc/beegfs/key.pem:/etc/beegfs/key.pem
+    #   - /etc/beegfs/cert.pem:/etc/beegfs/cert.pem
+    #   - /beegfs/connauthfile:/etc/beegfs/conn.auth
 
   beegfs-meta:
     image: ghcr.io/thinkparq/beegfs-meta:latest
@@ -65,24 +70,7 @@ services:
       - /beegfs/stor_01_tgt_101:/mnt/stor_01_tgt_101
       - /beegfs/stor_01_tgt_102:/mnt/stor_01_tgt_102
       # - /beegfs/connauthfile:/etc/beegfs/conn.auth
-      
-  debian-helper:
-    image: debian:12
-    container_name: debian-helper
-    command: tail -f /dev/null
-    networks:
-      - beegfs_1
-      - beegfs_2
-    environment:
-      - CONN_AUTH_FILE_DATA="Connection_Authentication_file_data"
-    volumes:
-      - /etc/beegfs/license.pem:/etc/beegfs/license.pem
-      # Enable the two lines below if you have a TLS certificate
-      - /etc/beegfs/key.pem:/etc/beegfs/key.pem
-      - /etc/beegfs/cert.pem:/etc/beegfs/cert.pem
-      # - /beegfs/connauthfile:/etc/beegfs/conn.auth
-    stdin_open: true
-    tty: true
+
 networks:
   beegfs_1:
     external: false

--- a/examples/docker-compose-v8.yml
+++ b/examples/docker-compose-v8.yml
@@ -15,19 +15,24 @@
 version: '3'
 services:
   beegfs-management:
-    image: ghcr.io/thinkparq/beegfs-mgmtd:latest   
+    image: ghcr.io/thinkparq/beegfs-mgmtd:latest
     container_name: beegfs-mgmtd
     privileged: true    
-    command: "storeMgmtdDirectory=/mnt/mgmt_tgt_mgmt01 storeAllowFirstRunInit=false connInterfacesList=eth0,eth1"
+    command: "--db-file /mnt/mgmt_tgt_mgmt01/mgmtd.sqlite  --interfaces eth0,eth1  --log-target stderr --tls-disable true"
     environment:
-      - beegfs_setup_1=beegfs-setup-mgmtd -p /mnt/mgmt_tgt_mgmt01 -C -S mgmt_tgt_mgmt01 
+      - beegfs_setup_1=beegfs-mgmtd --init --db-file /mnt/mgmt_tgt_mgmt01/mgmtd.sqlite  --log-target stderr 
       - CONN_AUTH_FILE_DATA="Connection_Authentication_file_data"
     networks: 
       - beegfs_1
       - beegfs_2
     volumes:
       - /beegfs/mgmt_tgt_mgmt01:/mnt/mgmt_tgt_mgmt01
-      # - /beegfs/connauthfile:/etc/beegfs/connauthfile
+      # Enable the line below if you have a license file
+      - /etc/beegfs/license.pem:/etc/beegfs/license.pem
+      # Enable the two lines below if you have a TLS certificate and remove the --tls-disable true from the command line
+      # - /etc/beegfs/key.pem:/etc/beegfs/key.pem
+      # - /etc/beegfs/cert.pem:/etc/beegfs/cert.pem
+      # - /beegfs/connauthfile:/etc/beegfs/conn.auth
 
   beegfs-meta:
     image: ghcr.io/thinkparq/beegfs-meta:latest
@@ -42,7 +47,7 @@ services:
       - beegfs_2
     volumes:
       - /beegfs/meta_01_tgt_0101:/mnt/meta_01_tgt_0101
-      # - /beegfs/connauthfile:/etc/beegfs/connauthfile
+      # - /beegfs/connauthfile:/etc/beegfs/conn.auth
 
   beegfs-storage:
     image: ghcr.io/thinkparq/beegfs-storage:latest
@@ -59,8 +64,25 @@ services:
     volumes:
       - /beegfs/stor_01_tgt_101:/mnt/stor_01_tgt_101
       - /beegfs/stor_01_tgt_102:/mnt/stor_01_tgt_102
-      # - /beegfs/connauthfile:/etc/beegfs/connauthfile
+      # - /beegfs/connauthfile:/etc/beegfs/conn.auth
       
+  debian-helper:
+    image: debian:12
+    container_name: debian-helper
+    command: tail -f /dev/null
+    networks:
+      - beegfs_1
+      - beegfs_2
+    environment:
+      - CONN_AUTH_FILE_DATA="Connection_Authentication_file_data"
+    volumes:
+      - /etc/beegfs/license.pem:/etc/beegfs/license.pem
+      # Enable the two lines below if you have a TLS certificate
+      - /etc/beegfs/key.pem:/etc/beegfs/key.pem
+      - /etc/beegfs/cert.pem:/etc/beegfs/cert.pem
+      # - /beegfs/connauthfile:/etc/beegfs/conn.auth
+    stdin_open: true
+    tty: true
 networks:
   beegfs_1:
     external: false

--- a/servers/init.py
+++ b/servers/init.py
@@ -22,7 +22,6 @@ import subprocess
 logging.basicConfig(level=logging.DEBUG, format='%(asctime)s %(levelname)s [%(filename)s]: %(message)s')
 log = logging.getLogger()
 
-conn_auth_file_path = "/etc/beegfs/connAuthFile"
 beegfs_service_type = ""
 store_beegfs_directory = ""
 beegfs_database_path = ""
@@ -34,11 +33,20 @@ if 'BEEGFS_VERSION' not in os.environ:
 beegfs_major_version = int(os.environ.get('BEEGFS_VERSION')[0])
 log.info(f"BeeGFS version: {beegfs_major_version}")
 
-# Pass connauthfile secret as environment vaiable 
-if 'CONN_AUTH_FILE_DATA' in os.environ:
-    with open(conn_auth_file_path, "w") as fp:
-        conn_auth_val = os.environ.get('CONN_AUTH_FILE_DATA')
-        fp.write(conn_auth_val.replace('\\n', '\n') + '\n')
+
+file_env_mapping = {
+    'CONN_AUTH_FILE_DATA': "/etc/beegfs/conn.auth",
+    'BEEGFS_LICENSE_FILE_DATA': "/etc/beegfs/license.pem",
+    'TLS_KEY_FILE_DATA': "/etc/beegfs/key.pem",
+    'TLS_CERT_FILE_DATA': "/etc/beegfs/cert.pem"
+}
+
+# Check if the environment variables are set and write their values to the corresponding files.
+for env_var, file_path in file_env_mapping.items():
+    if env_var in os.environ:
+        with open(file_path, "w") as fp:
+            file_data = os.environ.get(env_var)
+            fp.write(file_data.replace('\\n', '\n') + '\n')
 
 # Determine any commands that will be used to setup BeeGFS targets:
 beegfs_setup = []

--- a/servers/init.py
+++ b/servers/init.py
@@ -25,6 +25,14 @@ log = logging.getLogger()
 conn_auth_file_path = "/etc/beegfs/connAuthFile"
 beegfs_service_type = ""
 store_beegfs_directory = ""
+beegfs_database_path = ""
+
+if 'BEEGFS_VERSION' not in os.environ:
+    log.critical("The BEEGFS_VERSION environment variable is not set. This is required to determine the BeeGFS version.")
+    sys.exit(1)
+
+beegfs_major_version = int(os.environ.get('BEEGFS_VERSION')[0])
+log.info(f"BeeGFS version: {beegfs_major_version}")
 
 # Pass connauthfile secret as environment vaiable 
 if 'CONN_AUTH_FILE_DATA' in os.environ:
@@ -38,7 +46,10 @@ for key, value in os.environ.items():
     if "BEEGFS_SERVICE" in key: 
         if value == "beegfs-mgmtd":
             beegfs_service_type = value
-            store_beegfs_directory = "storeMgmtdDirectory"
+            if beegfs_major_version == 7:
+                store_beegfs_directory = "storeMgmtdDirectory"
+            else:
+                beegfs_database_path = "--db-file"
         if value == "beegfs-meta":
             beegfs_service_type = value
             store_beegfs_directory = "storeMetaDirectory"
@@ -60,8 +71,22 @@ beegfs_args = sys.argv[1:]
 # Determine BeeGFS targets configured specified in command line arguments:
 beegfs_targets=[]
 for arg in beegfs_args:
-    if store_beegfs_directory in arg:
+    if store_beegfs_directory and store_beegfs_directory in arg:
         beegfs_targets = arg.split("=")[1].split(",")
+
+# BeeGFS V8 management does not use a mount directory; instead, add the database file's basepath in beegfs_targets.
+if '--db-file' in beegfs_args:
+    if '--db-file=' in ' '.join(beegfs_args):
+        beegfs_database_path = [arg.split('=')[1] for arg in beegfs_args if arg.startswith('--db-file=')][0]
+    elif '--db-file' in beegfs_args:
+        beegfs_database_path = beegfs_args[beegfs_args.index('--db-file') + 1]
+    
+    if os.path.exists(beegfs_database_path):
+        log.info(f"BeeGFS Mgmtd database path {beegfs_database_path} already exists.")
+    else:
+        log.info(f"BeeGFS Mgmtd database path {beegfs_database_path} does not exist, creating it.")
+        os.makedirs(os.path.dirname(beegfs_database_path), exist_ok=True)
+    beegfs_targets = [os.path.dirname(beegfs_database_path)]
 
 # If BeeGFS should be configured using the setup scripts, ensure setup commands were provided for all targets specified
 # in the command line argument.
@@ -85,7 +110,7 @@ if len(beegfs_setup) > 0:
         if not found:
             log.critical("BeeGFS target '" + target + "' was included in " + store_beegfs_directory + " but there is not corresponding BeeGFS setup command.\n"\
                          "BeeGFS setup commands provided as environment variable(s) 'beegfs_setup_*': %s", beegfs_setup)
-            sys.exit(1)
+            sys.exit(1) 
 
     # Setup targets
 
@@ -96,10 +121,9 @@ if len(beegfs_setup) > 0:
                     log.info(f"BeeGFS target {target} was already initialized since {target}/alreadyInitByContainer exists.")
                     break
                 else:
-                    
                     # Without shell=True you will get "line 102: ${FORMAT_FILE_PATH}: ambiguous redirect"
                     setup_result = subprocess.run([setup], capture_output=True, shell=True, text=True)
-
+                    
                     if setup_result.returncode != 0:
                         log.critical(f"Setting up BeeGFS target {target} using command '{setup}' failed. \n" \
                                      f"=== command === \n {setup_result.args} \n === stdout ===\n {setup_result.stdout}\n === stderr === \n {setup_result.stderr}")

--- a/servers/start.sh
+++ b/servers/start.sh
@@ -32,22 +32,39 @@ fi
 if ! /root/init.py $@; then
 	echo "$(date --rfc-3339=ns) FATAL [start.sh]: An unrecoverable error was encountered while checking and initializing BeeGFS targets."
 	exit 1
-else
-    export CONN_AUTH_FILE_CONFIG=""
+fi
 
-    # Configure connection authentication file based on service type and BeegFS version
-    if [[ ! -z "${CONN_AUTH_FILE_DATA}" ]]; then
-        if [[ "${BEEGFS_SERVICE}" == "beegfs-mgmtd" && "${beegfs_major_version}" -ne 7 ]]; then
-            CONN_AUTH_FILE_CONFIG="--auth-file /etc/beegfs/connAuthFile"
-        else
-            CONN_AUTH_FILE_CONFIG="connAuthFile=/etc/beegfs/connAuthFile"
-        fi
+
+export CONFIG=""
+# Configure connection authentication file based on service type and BeeGFS version
+if [[ ! -z "${CONN_AUTH_FILE_DATA}" ]]; then
+    if [[ "${BEEGFS_SERVICE}" == "beegfs-mgmtd" && "${beegfs_major_version}" -ne 7 ]]; then
+        CONFIG="${CONFIG} --auth-file /etc/beegfs/conn.auth"
+    else
+        CONFIG="${CONFIG} connAuthFile=/etc/beegfs/conn.auth"
+    fi
+fi
+
+# Configure license and TLS files for mgmtd version 8 and above
+if [[ "${BEEGFS_SERVICE}" == "beegfs-mgmtd" && "${beegfs_major_version}" -ne 7 ]]; then
+    if [[ ! -z "${BEEGFS_LICENSE_FILE_DATA}" ]]; then
+        CONFIG="${CONFIG} --license-cert-file /etc/beegfs/license.pem"
     fi
 
-    echo "$(date --rfc-3339=ns) INFO [start.sh]: Attempting to start the BeeGFS '$BEEGFS_SERVICE' with arguments : $@ ${CONN_AUTH_FILE_CONFIG}"
-    # Use exec to replace the shell process so the BeeGFS service will directly receive signals sent to the container.
-    # This is important so we can shutdown gracefully and correctly write anything out to disk (like node states).
-    exec $BEEGFS_SERVICE $@ ${CONN_AUTH_FILE_CONFIG}
-    
+    if [[ ! -z "${TLS_KEY_FILE_DATA}" ]]; then
+        CONFIG="${CONFIG} --tls-key-file /etc/beegfs/key.pem"
+    fi
+
+    if [[ ! -z "${TLS_CERT_FILE_DATA}" ]]; then
+        CONFIG="${CONFIG} --tls-cert-file /etc/beegfs/cert.pem"
+    fi
 fi
+
+
+echo "$(date --rfc-3339=ns) INFO [start.sh]: Attempting to start the BeeGFS '$BEEGFS_SERVICE' with arguments : $@ ${CONFIG}"
+# Use exec to replace the shell process so the BeeGFS service will directly receive signals sent to the container.
+# This is important so we can shutdown gracefully and correctly write anything out to disk (like node states).
+exec $BEEGFS_SERVICE $@ ${CONFIG}
+    
+
 exit 0


### PR DESCRIPTION
Changes: 
- Added support for building Docker images of BeeGFS v8
- Modified Dockerfile and scripts to support building both v7 and v8 images
- Added new Docker Compose file to create a BeeGFS v8 cluster

Testing Conducted
- Verified V8 setup with TLS and authentication enabled using `beegfs-ctl`.
- Verified V8 setup with TLS and authentication disabled.
- Checked license verification in V8 using `beegfs-ctl` and management logs.
- Tested client mount on V8 setup.
- Confirmed V7 Docker image builds successfully.
- Verified V7 setup works correctly with the Docker Compose file.