### PR TITLE
ci(build): publish rolling minor and pinned patch versions

### DIFF
--- a/.github/workflows/build-publish.yaml
+++ b/.github/workflows/build-publish.yaml
@@ -6,7 +6,7 @@ on:
     # The ${{ github.ref_name }} is used as the BeeGFS version so this workflow should only be
     # triggered by pushing tags that match the BeeGFS semantic versioning scheme.
     tags:
-      - "[0-9].[0-9].[0-9]"
+      - "[0-9].[0-9]"
 
 env:
   REGISTRY: ghcr.io
@@ -20,7 +20,6 @@ jobs:
     strategy:
       matrix:
         include:
-          - image_name: beegfs-all
           - image_name: beegfs-mgmtd
           - image_name: beegfs-meta
           - image_name: beegfs-storage
@@ -48,6 +47,30 @@ jobs:
         with:
           cosign-release: "v2.1.1"
 
+      - name: Determine BeeGFS package version
+        id: pkg
+        if: startsWith(github.ref, 'refs/tags/')
+        env:
+          BEEGFS_REPO_VERSION: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          repo_version="${BEEGFS_REPO_VERSION}"
+          tmpdir="$(mktemp -d)"
+          curl -fsSL "https://www.beegfs.io/release/beegfs_${repo_version}/gpg/GPG-KEY-beegfs" -o "${tmpdir}/beegfs.asc"
+          sudo install -o root -g root -m 644 "${tmpdir}/beegfs.asc" /etc/apt/trusted.gpg.d/beegfs.asc
+          curl -fsSL "https://www.beegfs.io/release/beegfs_${repo_version}/dists/beegfs-bookworm.list" -o "${tmpdir}/beegfs.list"
+          sudo install -o root -g root -m 644 "${tmpdir}/beegfs.list" /etc/apt/sources.list.d/beegfs.list
+          sudo apt-get update
+          package="${{ matrix.image_name }}"
+          candidate="$(apt-cache madison "${package}" | awk 'NR==1 {print $3}')"
+          if [ -z "${candidate}" ]; then
+            echo "Unable to determine package version for ${package}" >&2
+            exit 1
+          fi
+          version="${candidate#*:}" # Drop epoch but keep any suffix (e.g. -beta.0).
+          echo "candidate=${candidate}" >> "$GITHUB_OUTPUT"
+          echo "semantic=${version}" >> "$GITHUB_OUTPUT"
+
       - name: Determine metadata for BeeGFS image
         id: meta
         uses: docker/metadata-action@v5.5.1
@@ -56,8 +79,9 @@ jobs:
           tags: |
             type=ref,event=branch
             type=ref,event=pr
-            type=semver,pattern={{version}},prefix=
-            type=semver,pattern={{major}}.{{minor}},prefix=
+            type=raw,value=latest,enable=${{ github.ref_type == 'tag' }}
+            type=raw,value=${{ github.ref_name }},enable=${{ github.ref_type == 'tag' }}
+            type=raw,value=${{ steps.pkg.outputs.semantic }},enable=${{ github.ref_type == 'tag' }}
 
       - name: Build and push image for each supported platform
         uses: docker/build-push-action@v5.1.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,8 @@ RUN apt-get update && apt-get install procps kmod iptables xfsprogs iproute2 ca-
 # Install Optional Utilities:
 RUN apt-get update && apt-get install nano vim dstat sysstat -y && rm -rf /var/lib/apt/lists/*
 
-# Install Beegfs binaries from the public repo.
+# Install Beegfs binaries from the public repo. If/when these URLs change ensure to also update the
+# equivalent URLs in the build-publish.yaml workflow step used to determine BeeGFS package versions.
 RUN wget https://www.beegfs.io/release/beegfs_$BEEGFS_VERSION/gpg/GPG-KEY-beegfs -O /etc/apt/trusted.gpg.d/beegfs.asc
 RUN wget https://www.beegfs.io/release/beegfs_$BEEGFS_VERSION/dists/beegfs-bookworm.list -P /etc/apt/sources.list.d/
 
@@ -75,12 +76,3 @@ ENV BEEGFS_SERVICE=$BEEGFS_SERVICE
 RUN apt-get update && apt-get install $BEEGFS_SERVICE libbeegfs-ib -y && rm -rf /var/lib/apt/lists/*
 RUN rm -rf /etc/beegfs/*conf
 ENTRYPOINT ["/root/start.sh"]
-
-
-# Build beegfs-all docker image with `docker build -t repo/image-name  --target beegfs-all .`  
-FROM --platform=$TARGETPLATFORM base AS beegfs-all
-ARG BEEGFS_SERVICE="beegfs-all"
-RUN apt-get update && apt-get install libbeegfs-ib beegfs-mgmtd beegfs-meta beegfs-storage -y && rm -rf /var/lib/apt/lists/*
-RUN rm -rf /etc/beegfs/*conf
-ENTRYPOINT ["/root/start.sh"]
-# arguments passed as commands in docker run will be passed as arguments to start.sh inturn passed to BeeGFS service.


### PR DESCRIPTION
Starting with BeeGFS 8, package repositories exist for each major.minor version, and patch releases are released as needed into these repos. This commit updates the release workflow so a major.minor tag is pushed which determines the major.minor version of the images, but the patch version is determined by looking at the package versions in the package repo.

This also removes the beegfs-all container image to avoid mismatched tagging.